### PR TITLE
Create a logger to record manual work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# log file from tests
+manual-work.md

--- a/codemods/inline-style-prop/convert-object-properties.ts
+++ b/codemods/inline-style-prop/convert-object-properties.ts
@@ -11,16 +11,17 @@ import {
   _isRemovable,
   _isSupported,
 } from "../../examples/styled-components-to-ucl/utils";
+import { logManualWork } from "../../logger";
 
 export function convertObjectProperties(
+  filePath: string,
   j: JSCodeshift,
   properties: Array<
     Property | ObjectProperty | SpreadElement | SpreadProperty | ObjectMethod
   >,
   needsFlexRemapping: boolean,
-): Array<ObjectProperty> {
+): Array<ObjectProperty | SpreadElement> {
   return properties.reduce((properties, node) => {
-    // TODO: Do we need to handle spread elements?
     if (
       node.type === "ObjectProperty" &&
       node.key.type === "Identifier" &&
@@ -72,6 +73,34 @@ export function convertObjectProperties(
           ),
         );
       });
+    } else if (node.type === "SpreadElement") {
+      const spreadName =
+        node.argument.type === "Identifier"
+          ? node.argument.name
+          : // is it ever not an identifier?
+            "UNKNOWN_IDENTIFIER";
+
+      logManualWork({
+        filePath,
+        helpfulMessage: `The codemod for handling inline style props found a style attribute with an object spread into it.
+We are unable to verify that this spread object contains entirely valid CSS for react native.
+
+The manual effort here is to track down the variable and verify/change all instances to ensure they are react native compatible.
+
+For example, if the \`${spreadName}\` variable is an import, follow the import (and its respective brand overrides), and verify all of the keys are react native compatible.
+
+If the \`${spreadName}\` variable is a prop coming in from the parent, find all usages of this component, and ensure the prop passed in is valid react native styles.`,
+        startingLine: node.loc.start.line,
+        endingLine: node.loc.end.line,
+      });
+
+      properties.push(
+        // @ts-ignore
+        j.commentLine(
+          " TODO: RN - Verify spread does not include invalid props or styles",
+        ),
+        node,
+      );
     } else {
       throw new Error(
         `Unexpected node type in object of style prop ${node.type}`,
@@ -79,5 +108,5 @@ export function convertObjectProperties(
     }
 
     return properties;
-  }, [] as ObjectProperty[]);
+  }, [] as (ObjectProperty | SpreadElement)[]);
 }

--- a/codemods/inline-style-prop/index.ts
+++ b/codemods/inline-style-prop/index.ts
@@ -1,10 +1,18 @@
-import { API, FileInfo, ObjectProperty } from "jscodeshift";
+import {
+  API,
+  FileInfo,
+  ObjectMethod,
+  ObjectProperty,
+  Property,
+  SpreadElement,
+  SpreadProperty,
+} from "jscodeshift";
 import _ from "lodash";
-import toRN from "css-to-react-native";
 import {
   _isRemovable,
   _isSupported,
 } from "../../examples/styled-components-to-ucl/utils";
+import { logManualWork, commitManualLogs } from "../../logger";
 import { convertObjectProperties } from "./convert-object-properties";
 
 export const parser = "tsx";
@@ -24,6 +32,7 @@ export default function transformer(file: FileInfo, api: API) {
         styleAttribute.value.expression.type === "ObjectExpression"
       ) {
         styleAttribute.value.expression.properties = convertObjectProperties(
+          file.path,
           j,
           styleAttribute.value.expression.properties,
           needsFlexRemapping(styleAttribute.value.expression.properties),
@@ -54,6 +63,7 @@ export default function transformer(file: FileInfo, api: API) {
               node.value.type === "ObjectExpression"
             ) {
               node.value.properties = convertObjectProperties(
+                file.path,
                 j,
                 node.value.properties,
                 needsFlexRemapping(node.value.properties),
@@ -71,11 +81,18 @@ export default function transformer(file: FileInfo, api: API) {
         styleAttribute.value.expression.type === "Identifier"
       ) {
         const objectName = styleAttribute.value.expression.name;
+
+        // Check to see if the object is a variable in the module scope
+        // if not, we handle it below
+        let foundVariables = false;
+
         root.findVariableDeclarators(objectName).forEach((path) => {
+          foundVariables = true;
           if (path.value.init.type === "ObjectExpression") {
             const node = path.value.init;
 
             node.properties = convertObjectProperties(
+              file.path,
               j,
               node.properties,
               needsFlexRemapping(node.properties),
@@ -83,22 +100,76 @@ export default function transformer(file: FileInfo, api: API) {
           }
         });
 
+        if (!foundVariables) {
+          const nodeName =
+            node.value.openingElement.name.type === "JSXIdentifier"
+              ? node.value.openingElement.name.name
+              : // not sure what to do here for JSXMemberExpression and JSXNamespaced
+                "UNKNOWN_NODE_NAME";
+
+          logManualWork({
+            filePath: file.path,
+            helpfulMessage: `The JSX node <${nodeName} style={${objectName}}> has a style attribute that references a variable this is not modable.
+The manual effort here is to track down the variable and verify/change all instances to ensure they are react native compatible.
+
+For example, if the \`${objectName}\` variable is an import, follow the import (and its respective brand overrides), and verify all of the keys are react native compatible.
+
+If the \`${objectName}\` variable is a prop coming in from the parent, find all usages of this component, and ensure the prop passed in is valid react native styles.
+`,
+            startingLine: node.value.loc.start.line,
+            endingLine: node.value.loc.end.line,
+          });
+        }
+
         return;
       }
 
-      // console.error(
-      //   "Not sure how to handle this `style` attribute with AST type of ",
-      //   styleAttribute.value.type,
-      // );
+      // This is for style={[ any ]}, which only happens in react native. so its safe to ignore
+      if (
+        styleAttribute.value.type === "JSXExpressionContainer" &&
+        styleAttribute.value.expression.type === "ArrayExpression"
+      )
+        return;
+
+      console.error(
+        "Not sure how to handle this `style` attribute with AST type of ",
+        styleAttribute.value.type,
+      );
     }
   });
 
-  return root.toSource({ quote: "single" });
+  const source = root.toSource({ quote: "single" });
+
+  commitManualLogs(source);
+  return source;
 }
 
-const needsFlexRemapping = (properties: any) =>
-  properties.some(
+// only needs to remap if the node had flex, but did not have a flex direction,
+// meaning that the flex direction is going to be implicitly flipped by switching to react-native
+const needsFlexRemapping = (
+  properties: (
+    | Property
+    | ObjectProperty
+    | SpreadElement
+    | SpreadProperty
+    | ObjectMethod
+  )[],
+) => {
+  const hasFlex = properties.some(
     (node) =>
-      // @ts-ignore
-      node.key.name === "display" && node.value.value === "flex",
+      node.type === "ObjectProperty" &&
+      node.key.type === "Identifier" &&
+      node.key.name === "display" &&
+      node.value.type === "StringLiteral" &&
+      node.value.value === "flex",
   );
+
+  const hasFlexDirection = properties.some(
+    (node) =>
+      node.type === "ObjectProperty" &&
+      node.key.type === "Identifier" &&
+      node.key.name === "flexDirection",
+  );
+
+  return hasFlex && !hasFlexDirection;
+};

--- a/examples/__testfixtures__/inline-style-prop/styles-with-spread.input.tsx
+++ b/examples/__testfixtures__/inline-style-prop/styles-with-spread.input.tsx
@@ -1,0 +1,7 @@
+function C({ styles }) {
+    return <div style={{
+      height: '1rem',
+      width: '83px',
+      ...styles,
+   }}>hi</div>;
+  }

--- a/examples/__testfixtures__/inline-style-prop/styles-with-spread.output.tsx
+++ b/examples/__testfixtures__/inline-style-prop/styles-with-spread.output.tsx
@@ -1,0 +1,10 @@
+function C({ styles }) {
+    return (
+     <div style={{
+      height: '$4',
+      width: '83px',
+      // TODO: RN - Verify spread does not include invalid props or styles,
+      ...styles
+     }}>hi</div>
+    );
+  }

--- a/examples/__testfixtures__/rename-jsx-primitives/basic.output.tsx
+++ b/examples/__testfixtures__/rename-jsx-primitives/basic.output.tsx
@@ -19,19 +19,19 @@ function H1() {
 }
 
 function H2() {
-  return <Header accessibilityLevel={2} variant='headerTwo'>Hi</Header>;
+  return <Header variant='headerTwo'>Hi</Header>;
 }
 
 function H3() {
-  return <Header accessibilityLevel={3} variant='headerThree'>Hi</Header>;
+  return <Header variant='headerThree'>Hi</Header>;
 }
 
 function H4() {
-  return <Header accessibilityLevel={4} variant='headerFour'>Hi</Header>;
+  return <Header variant='headerFour'>Hi</Header>;
 }
 
 function H5() {
-  return <Header accessibilityLevel={5} variant='headerFive'>Hi</Header>;
+  return <Header variant='headerFive'>Hi</Header>;
 }
 
 function InlineBR() {

--- a/examples/__tests__/inline-style-prop.spec.ts
+++ b/examples/__tests__/inline-style-prop.spec.ts
@@ -30,4 +30,11 @@ describe("renaming a variable", () => {
     "inline-style-prop/flex-flip",
     { parser: "tsx" },
   );
+  defineTest(
+    __dirname,
+    "../codemods/inline-style-prop",
+    null,
+    "inline-style-prop/styles-with-spread",
+    { parser: "tsx" },
+  );
 });

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,54 @@
+import * as fs from "fs";
+import * as uuid from "uuid";
+
+type Props = {
+  filePath: string;
+  helpfulMessage: string;
+  startingLine: number;
+  endingLine: number;
+};
+
+let logs: Props[] = [];
+
+export function logManualWork(props: Props) {
+  logs.push(props);
+}
+
+export function commitManualLogs(source) {
+  fs.appendFileSync(
+    "./manual-work.md",
+    logs
+      .map(
+        (m) => `
+# Manual Work ID: ${uuid.v4()}
+-------------------------------------------------------
+file: \`${m.filePath.replace(process.cwd(), "")}\`
+
+### Information:
+${m.helpfulMessage}
+
+_Verify that the conversion is correct. L${m.startingLine}:L${m.endingLine}_
+
+\`\`\`tsx
+${printSource(source, m.startingLine, m.endingLine)}
+\`\`\`
+  `,
+      )
+      .join("\n"),
+  );
+
+  logs = [];
+}
+
+function printSource(source: string, start: number, end: number) {
+  const lines = source.split("\n");
+
+  // add 4 surrounding lines.
+  const startingLine = start - 4 < 0 ? 0 : start - 4;
+  const endingLine = end + 4;
+
+  return lines
+    .splice(startingLine, endingLine)
+    .map((l, i) => `${i + startingLine + 1}`.padStart(2, " ") + `| ${l}`)
+    .join("\n");
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postcss": "^8.4.6",
     "postcss-js": "^4.0.0",
     "postcss-scss": "^4.0.3",
-    "prettier": "^2.5.1"
+    "prettier": "^2.5.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/jest": "^27.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,6 +3481,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz#77b752fd3975e31bbcef938f85e9bd1c7a8d60ed"


### PR DESCRIPTION
This creates methods to add a logger for manual work to be done by the engineers after the codemod is complete.

Also in this PR is a couple fixes:

1. Dont' add accessibilityLevel for h2->h5
2. Don't crash on spread props in a style attribute, log manual work
3. log manual work for style attributes that come from outside of the module