### PR TITLE
Include a file from UCL that was crashing and fix it

### DIFF
--- a/codemods/styled-components-to-ucl.ts
+++ b/codemods/styled-components-to-ucl.ts
@@ -1,4 +1,4 @@
-import { Collection, FileInfo, JSCodeshift } from "jscodeshift";
+import { Collection, FileInfo, JSCodeshift, types } from "jscodeshift";
 import {
   getElementMapping,
   styledComponentImportFunctionShouldBeRemove,
@@ -6,6 +6,7 @@ import {
 import { processElement } from "./utils/parse-element";
 import * as _ from "lodash/fp";
 import { registerUCLImportSpecifiers } from "./utils/register-ucl-import-specifiers";
+import { logManualWork } from "../logger";
 
 export function transformStyledCompoentsToUCL(
   root: Collection<any>,
@@ -92,10 +93,19 @@ export function transformStyledCompoentsToUCL(
     })
     .closest(j.TaggedTemplateExpression)
     .forEach((nodePath) => {
-      // @ts-ignore
+      if (
+        !(
+          nodePath.node.tag.type === "MemberExpression" &&
+          nodePath.node.tag.property.type === "Identifier"
+        )
+      ) {
+        // TODO: Replace node with mocked component, log manual work?
+        throw new Error("Error #jj43");
+        return;
+      }
+
       const elementPropName = nodePath.node.tag.property.name;
       // styled.XXX
-      // @ts-ignore
       const activeElement = getElementMapping(elementPropName);
       const expression = processElement({
         j,
@@ -118,8 +128,52 @@ export function transformStyledCompoentsToUCL(
     .closest(j.TaggedTemplateExpression)
     .forEach((nodePath) => {
       const { node } = nodePath;
-      // @ts-ignore
-      const nameOfArg = node.tag?.arguments[0]?.name;
+      if (node.tag.type !== "CallExpression") {
+        throw new Error(
+          "this should always be call expression based on the find/closest calls.",
+        );
+      }
+
+      if (node.tag.arguments[0]?.type !== "Identifier") {
+        const variable = walkUpToFind(nodePath, j, "VariableDeclarator");
+
+        if (!variable) throw new Error("coudlnt find the variable");
+
+        logManualWork({
+          filePath: fileInfo.path,
+          helpfulMessage: `The codemod to convert styled components to UCL nodes could not guarantee the correctness when encountering the variable for \`${
+            variable.id.name
+          }\`.
+
+Please manually convert the following styled component code into UCL and replace the null arrow function.
+
+\`\`\`tsx
+${j(variable).toSource()}
+\`\`\`
+`,
+          startingLine: 0,
+          endingLine: 0,
+          skipSource: true,
+        });
+
+        j(nodePath).replaceWith(
+          j.arrowFunctionExpression.from({
+            comments: [
+              j.commentLine(
+                " TODO: RN - This styled component could not be codemoded. Check manual-work/*.md for guidance",
+                false,
+                true,
+              ),
+            ],
+            params: [],
+            body: j.nullLiteral(),
+          }),
+        );
+
+        return;
+      }
+
+      const nameOfArg = node.tag.arguments[0].name;
       const expression = processElement({
         j,
         nodePath,
@@ -161,4 +215,31 @@ export function transformStyledCompoentsToUCL(
   } else {
     styledImport.remove();
   }
+}
+
+type ASTTypes = typeof types.namedTypes;
+
+function walkUpToFind<T extends keyof ASTTypes>(
+  node: any,
+  j: JSCodeshift,
+  type: T,
+  // ): ASTTypes[T] | null {
+): any | null {
+  let foundNode;
+  j(node).forEach((path) => {
+    if (foundNode) return;
+
+    if (path.value.type === type) {
+      foundNode = path.value;
+      return;
+    }
+
+    if (!path.parentPath) {
+      return;
+    }
+
+    foundNode = walkUpToFind(path.parentPath.value, j, type);
+  });
+
+  return foundNode || null;
 }

--- a/examples/__testfixtures__/wl-components/reward-categories/components/styled.input.tsx
+++ b/examples/__testfixtures__/wl-components/reward-categories/components/styled.input.tsx
@@ -1,0 +1,142 @@
+import styled, { css } from 'styled-components';
+
+import { ClickableContainer } from 'components/clickable-container';
+import { brandFont } from 'components/layout/brand-font';
+import { LinkButton } from 'components/link-button';
+import { primitive } from 'styles/constants/primitives';
+import { filterProps } from 'utils/filter-props';
+import { screenReaderOnly } from 'utils/style/screen-reader-only';
+
+import { RewardsStyleVariant, WithStyleVariant } from '../types';
+
+import { CategoryDropdownProps, OptionsContainerProps } from './types';
+
+export const CategoryTitle = styled.h5<WithStyleVariant>`
+  height: 3rem;
+  flex-wrap: wrap;
+  margin: 0rem;
+  display: flex;
+  align-items: center;
+  color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? theme.token('text-reversed')
+      : theme.token('text-default')};
+  font-weight: ${({ variant }) =>
+    variant === RewardsStyleVariant.Secondary ? Styles.fontWeight.normal : 'inherit'};
+  ${Styles.desktop`
+  font-size:1.2rem;
+`}
+`;
+
+export const noBottomBorder = css`
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+`;
+
+export const CategoryContainer = styled.div<WithStyleVariant>`
+  padding: 0 ${primitive.$spacing4};
+  border-width: 1px;
+  border-style: solid;
+  border-color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? primitive.th.$alwaysRedDarken10
+      : theme.token('border-color-default')};
+  border-radius: 0.5rem;
+  background-color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? primitive.th.$alwaysRedDarken10
+      : theme.token('background-pattern')};
+  box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.1);
+`;
+
+export const Fieldset = styled.fieldset`
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.token('border-color-default')};
+  margin: 0;
+  padding: 0;
+  width: 100%;
+`;
+
+export const HiddenLegend = styled.legend`
+  ${screenReaderOnly};
+`;
+
+export const CategoryDropdownContainer = styled(CategoryContainer)<
+  Pick<CategoryDropdownProps, 'optionsVisible' | 'overlay'>
+>`
+  position: relative;
+  width: 100%;
+  padding: 0;
+  ${({ optionsVisible, overlay }) => overlay && optionsVisible && noBottomBorder};
+`;
+
+export const TitleContainer = styled.div`
+  padding: ${primitive.$spacing2} ${primitive.$spacing4} 0;
+  width: 100%;
+`;
+
+export const Title = styled(ClickableContainer)<
+  { isUsingTabNavigation: boolean; showBorder: boolean; bold: boolean } & WithStyleVariant
+>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: ${({ bold }) => bold && Styles.fontWeight.heavy};
+  border-bottom: ${({ showBorder }) => (showBorder ? '1px' : '0px')};
+  border-bottom-style: solid;
+  border-bottom-color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? primitive.$blackOpacity30
+      : theme.token('border-color-default')};
+
+  &:focus {
+    ${({ isUsingTabNavigation }) => !isUsingTabNavigation && 'outline: none;'};
+  }
+
+  width: 100%;
+  padding-bottom: ${primitive.$spacing2};
+
+  & > {
+    height: 3rem;
+  }
+`;
+
+export const overlayStyle = css<OptionsContainerProps>`
+  position: absolute;
+  width: calc(100% + 2px);
+  left: -1px;
+  background: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? primitive.th.$alwaysRedDarken10
+      : theme.token('background-pattern')};
+  z-index: ${Styles.zIndex.below};
+  border-width: 1px;
+  border-style: solid;
+  border-color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? primitive.th.$alwaysRedDarken10
+      : theme.token('border-color-default')};
+  border-top: none;
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+`;
+
+export const OptionsContainer = styled.div<OptionsContainerProps>`
+  ${({ overlay }) => overlay && overlayStyle}
+  padding: 0 ${primitive.$spacing4};
+  z-index: ${Styles.zIndex.normal};
+  ${({ focusOptionsWhenNotVisible, optionsVisible }) =>
+    !optionsVisible && (focusOptionsWhenNotVisible ? screenReaderOnly : 'display: none;')};
+`;
+
+export const SeeMoreOptionsCTA = styled(filterProps(LinkButton, 'variant'))<WithStyleVariant>`
+  width: 100%;
+  padding: ${primitive.$spacing6} 0 ${primitive.$spacing7};
+  text-align: left;
+  font: ${brandFont.copyOne};
+  color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? theme.token('text-link-reversed')
+      : theme.token('text-link-default')};
+`;

--- a/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
+++ b/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
@@ -1,0 +1,209 @@
+import { Box, Header } from '@rbilabs/universal-components';
+
+import { ClickableContainer } from 'components/clickable-container';
+import { brandFont } from 'components/layout/brand-font';
+import { LinkButton } from 'components/link-button';
+import { primitive } from 'styles/constants/primitives';
+import { filterProps } from 'utils/filter-props';
+import { screenReaderOnly } from 'utils/style/screen-reader-only';
+
+import { RewardsStyleVariant, WithStyleVariant } from '../types';
+
+import { CategoryDropdownProps, OptionsContainerProps } from './types';
+
+export const CategoryTitle = Header.withConfig<{
+  variant: boolean
+}>(p => ({
+  height: '$12',
+  flexWrap: 'wrap',
+  margin: 0,
+  justifyContent: 'center',
+
+  color: p.variant
+    ? '__legacyToken.text-reversed'
+    : '__legacyToken.text-default',
+
+  fontWeight: p.variant ? Styles.fontWeight.normal : 'inherit',
+
+  fontSize: {
+    lg: 19,
+  },
+}));
+
+export const noBottomBorder = {
+  borderWidth: 0,
+  borderColor: 'black',
+  borderStyle: 'solid',
+  borderBottomLeftRadius: 0,
+  borderBottomRightRadius: 0,
+};
+
+export const CategoryContainer = Box.withConfig<{
+  variant: boolean
+}>(p => ({
+  paddingX: '$4',
+  paddingY: 0,
+  borderTopWidth: 1,
+  borderRightWidth: 1,
+  borderBottomWidth: 1,
+  borderLeftWidth: 1,
+  borderStyle: 'solid',
+
+  borderTopColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderRightColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderBottomColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderLeftColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderTopLeftRadius: 8,
+  borderTopRightRadius: 8,
+  borderBottomRightRadius: 8,
+  borderBottomLeftRadius: 8,
+
+  backgroundColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.background-pattern',
+
+  // TODO RN: unsupported CSS
+  // boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.1)',
+}));
+
+export const Fieldset = Box.withConfig({
+  borderWidth: 0,
+  borderColor: 'black',
+  borderStyle: 'solid',
+  borderTopWidth: 1,
+  borderTopColor: '__legacyToken.border-color-default',
+  borderTopStyle: 'solid',
+  margin: 0,
+  padding: 0,
+  width: '100%',
+});
+
+export const HiddenLegend = Box.withConfig({
+  ...screenReaderOnly,
+});
+
+export const CategoryDropdownContainer = CategoryContainer.withConfig({
+  width: '100%',
+  padding: 0,
+  // ${({ optionsVisible, overlay }) => overlay && optionsVisible && noBottomBorder};
+});
+
+export const TitleContainer = Box.withConfig({
+  paddingTop: '$2',
+  paddingRight: '$4',
+  paddingBottom: 0,
+  paddingLeft: '$4',
+  width: '100%',
+});
+
+export const Title = ClickableContainer.withConfig<{
+  showBorder: boolean,
+  variant: boolean
+}>(p => ({
+  alignItems: 'space-between',
+  justifyContent: 'center',
+  borderBottomWidth: 1,
+  borderBottomColor: p.showBorder ? '1px' : '0px',
+  borderBottomStyle: 'solid',
+  borderBottomStyle: 'solid',
+
+  borderBottomColor: p.variant
+    ? 'blackOpacity.30'
+    : '__legacyToken.border-color-default',
+
+  width: '100%',
+  paddingBottom: '$2',
+}))/*
+TODO RN: unsupported CSS
+Some attributes were not converted.
+
+export const Title = styled(ClickableContainer)<
+  { isUsingTabNavigation: boolean; showBorder: boolean; bold: boolean } & WithStyleVariant
+>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: ${({ bold }) => bold && Styles.fontWeight.heavy};
+  border-bottom: ${({ showBorder }) => (showBorder ? '1px' : '0px')};
+  border-bottom-style: solid;
+  border-bottom-color: ${({ variant, theme }) =>
+    variant === RewardsStyleVariant.Secondary
+      ? primitive.$blackOpacity30
+      : theme.token('border-color-default')};
+
+  &:focus {
+    ${({ isUsingTabNavigation }) => !isUsingTabNavigation && 'outline: none;'};
+  }
+
+  width: 100%;
+  padding-bottom: ${primitive.$spacing2};
+
+  & > {
+    height: 3rem;
+  }
+`;
+
+*/;
+
+export const overlayStyle = p => ({
+  position: 'absolute',
+
+  // TODO RN: unsupported CSS
+  // width: 'calc(100% + 2px)',
+
+  left: -1,
+
+  backgroundColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.background-pattern',
+
+  zIndex: Styles.zIndex.below,
+  borderTopWidth: 1,
+  borderRightWidth: 1,
+  borderBottomWidth: 1,
+  borderLeftWidth: 1,
+  borderStyle: 'solid',
+
+  borderTopColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderRightColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderBottomColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderLeftColor: p.variant
+    ? primitive.th.$alwaysRedDarken10
+    : '__legacyToken.border-color-default',
+
+  borderWidth: 0,
+  borderColor: 'black',
+  borderStyle: 'solid',
+  borderBottomLeftRadius: 8,
+  borderBottomRightRadius: 8,
+});
+
+export const OptionsContainer = Box.withConfig({
+  paddingX: '$4',
+  paddingY: 0,
+  zIndex: Styles.zIndex.normal,
+});
+
+export const SeeMoreOptionsCTA = // TODO: RN - This styled component could not be codemoded. Check manual-work/*.md for guidance
+() => null;

--- a/examples/__tests__/styled-components-to-ucl.spec.ts
+++ b/examples/__tests__/styled-components-to-ucl.spec.ts
@@ -36,4 +36,8 @@ describe("styled-components to UCL", () => {
   ].forEach(test => {
     defineTest(__dirname, '../codemods', null, test, { parser: 'tsx' });
   })
+
+
+  // WL components
+  defineTest(__dirname, '../codemods', null, 'wl-components/reward-categories/components/styled', { parser: 'tsx' });
 });

--- a/logger.ts
+++ b/logger.ts
@@ -7,6 +7,7 @@ type LogMeta = {
   helpfulMessage: string;
   startingLine: number;
   endingLine: number;
+  skipSource?: boolean;
 };
 
 let logs: LogMeta[] = [];
@@ -43,11 +44,16 @@ file: \`${m.filePath.replace(process.cwd(), "")}\`
 ### Information:
 ${m.helpfulMessage}
 
+${
+  m.skipSource
+    ? ""
+    : `
 _Verify that the conversion is correct. L${m.startingLine}:L${m.endingLine}_
 
 \`\`\`tsx
 ${printSource(source, m.startingLine, m.endingLine)}
-\`\`\`
+\`\`\``
+}
   `,
         )
         .join("\n"),


### PR DESCRIPTION
tried running codemod against codebase and hit a crash on a file. Included it in the test suite, and did some fixes.

1. Don't crash if we encounter `styled(fn(Component))`
2. Turn that into a null compnoent () => null, and add manual work.

Here's an example of the manual work:


# Log

# Manual Work ID: 575c1cb2-26aa-40a1-a81a-e248e51beee0
-------------------------------------------------------
file: `/examples/__testfixtures__/wl-components/reward-categories/components/styled.input.tsx`

### Information:
The codemod to convert styled components to UCL nodes could not guarantee the correctness when encountering the variable for `SeeMoreOptionsCTA`.

Please manually convert the following styled component code into UCL and replace the null arrow function.

```tsx
SeeMoreOptionsCTA = styled(filterProps(LinkButton, 'variant'))<WithStyleVariant>`
  width: 100%;
  padding: ${primitive.$spacing6} 0 ${primitive.$spacing7};
  text-align: left;
  font: ${brandFont.copyOne};
  color: ${({ variant, theme }) =>
    variant === RewardsStyleVariant.Secondary
      ? theme.token('text-link-reversed')
      : theme.token('text-link-default')};
`
```

