### PR TITLE
Carry over previous type definitions

### DIFF
--- a/codemods/utils/process-element.ts
+++ b/codemods/utils/process-element.ts
@@ -102,7 +102,7 @@ export const processElement = ({
           const { identifier, isRemovable, isSupported, isSkipable, value } = preToRNTransform(
             k,
             v,
-            obj,
+            obj
           );
           k = identifier;
           v = value;
@@ -249,18 +249,10 @@ ${ct}
     });
   }
   // Map Types
-  if (localVars.length && includeTypes) {
-    // Add types
-    // @ts-ignore
-    exprs.typeArguments = j.tsTypeParameterInstantiation([
-      j.tsTypeLiteral(
-        _.flow(
-          _.flatten,
-          _.uniqBy('name'),
-          _.map((v: any) => j.tsPropertySignature(j.identifier(v.name), j.tsTypeAnnotation(v.type)))
-        )(localVars)
-      ),
-    ]);
+  if (includeTypes) {
+    try {
+      exprs.typeArguments = j.tsTypeParameterInstantiation([getTypeParameter(nodePath, j)]);
+    } catch (e) {}
   }
   return exprs;
 };
@@ -352,3 +344,11 @@ const nodePathToString = nodePath => {
   }
   return 'And error occurred';
 };
+
+// tries to grab the type parameter from `styled.div<foo>` if it can
+function getTypeParameter(nodePath: any, j: JSCodeshift) {
+  const typeParameters = nodePath.node.typeParameters;
+  const typeRef = typeParameters?.params[0];
+
+  return typeRef;
+}

--- a/examples/__testfixtures__/styled-components-to-ucl/basic.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/basic.input.ts
@@ -4,7 +4,10 @@ import Modal from './modal';
 /**
  * Spreads children horizontally and centers them vertically
  */
-export const Basic = styled.div`
+export const Basic = styled.div<{
+  color: string;
+  backgroundColor: string
+}>`
   display: flex;
   position: relative;
   margin: 0 auto;
@@ -34,7 +37,7 @@ export const Header = styled.h1`
   text-decoration: none;
 `;
 
-export const Conditional = styled.div`
+export const Conditional = styled.div<{ reversed: boolean }>`
   color: ${p => (p.reversed ? p.theme.token('text-reversed') : p.theme.token('text-default'))};
   background-color: ${p => (p.reversed ? Styles.color.white : p.theme.token('text-default'))};
 `;

--- a/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
@@ -5,7 +5,7 @@ import Modal from './modal';
  * Spreads children horizontally and centers them vertically
  */
 export const Basic = Box.withConfig<{
-  color: string,
+  color: string;
   backgroundColor: string
 }>(p => ({
   alignSelf: 'center',
@@ -55,9 +55,7 @@ export const Header = UCLHeader.withConfig({
   variant: 'headerOne',
 });
 
-export const Conditional = Box.withConfig<{
-  reversed: boolean
-}>(p => ({
+export const Conditional = Box.withConfig<{ reversed: boolean }>(p => ({
   _text: {
     color: p.reversed ? '__legacyToken.text-reversed' : '__legacyToken.text-default',
   },

--- a/examples/__testfixtures__/styled-components-to-ucl/complex2.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex2.input.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { primitive } from 'styles/constants/primitives';
 
-export const CartItemEditContainer = styled.div`
+export const CartItemEditContainer = styled.div<{ color: string }>`
   color: ${props => props.color};
   button {
     background-color: ${Styles.color.cardBackground};

--- a/examples/__testfixtures__/styled-components-to-ucl/complex2.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex2.output.ts
@@ -1,9 +1,7 @@
 import { Box as UCLBox } from '@rbilabs/universal-components';
 import { primitive } from 'styles/constants/primitives';
 
-export const CartItemEditContainer = UCLBox.withConfig<{
-  color: string
-}>(p => ({
+export const CartItemEditContainer = UCLBox.withConfig<{ color: string }>(p => ({
   _text: {
     color: p.color,
   },
@@ -11,7 +9,7 @@ export const CartItemEditContainer = UCLBox.withConfig<{
 TODO: RN - unsupported CSS
 Some attributes were not converted.
 
-export const CartItemEditContainer = styled.div`
+export const CartItemEditContainer = styled.div<{ color: string }>`
   color: ${props => props.color};
   button {
     background-color: ${Styles.color.cardBackground};

--- a/examples/__testfixtures__/styled-components-to-ucl/complex4.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex4.input.ts
@@ -5,7 +5,7 @@ import { ModalHeading } from 'components/modal';
 import { Text } from './somthing';
 import theme from './theme';
 
-export const AnotherOne = styled.div`
+export const AnotherOne = styled.div<{ secondary: boolean }>`
   width: 40;
   height: 4rem;
   top: ${p => (p.secondary ? '5vh' : '10vh')};

--- a/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
@@ -5,9 +5,7 @@ import { ModalHeading } from 'components/modal';
 import { Text } from './somthing';
 import theme from './theme';
 
-export const AnotherOne = Box.withConfig<{
-  secondary: boolean
-}>(p => ({
+export const AnotherOne = Box.withConfig<{ secondary: boolean }>(p => ({
   width: '$10',
   height: '$16',
   top: p.secondary ? '5vh' : '10vh',

--- a/examples/__testfixtures__/styled-components-to-ucl/complex5.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex5.input.ts
@@ -16,12 +16,12 @@ export const ItemOfferHeading = styled.span<{ $isApplied: boolean }>`
   color: ${({ $isApplied }) => ($isApplied ? Styles.color.black : Styles.color.red)};
 `
 
-export const Y = styled.div<{ center: boolean }>`
+export const Y = styled.div<{ center: boolean, $isApplied: boolean }>`
   color: ${({ $isApplied }) => ($isApplied ? Styles.color.black : Styles.color.red)};
   align-items: ${props => (props.center ? 'center' : 'flex-end')};
 `;
 
-export const Z = styled.div<{ center: boolean }>`
+export const Z = styled.div<{ center: boolean, $isApplied: boolean }>`
   align-items: ${props => (props.center ? 'center' : 'flex-end')};
   align-self: ${({ center }) => (center ? 'center' : 'flex-end')};
   color: ${({ $isApplied }) => ($isApplied ? Styles.color.black : Styles.color.red)};

--- a/examples/__testfixtures__/styled-components-to-ucl/complex5.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex5.output.ts
@@ -1,8 +1,6 @@
 import { Box } from '@rbilabs/universal-components';
 
-export const UnauthenticatedContainer = Box.withConfig<{
-  center: boolean
-}>(p => ({
+export const UnauthenticatedContainer = Box.withConfig<{ center: boolean }>(p => ({
   paddingX: 0,
   paddingY: '$4',
   flexWrap: 'wrap',
@@ -14,9 +12,7 @@ export const UnauthenticatedContainer = Box.withConfig<{
   },
 }));
 
-export const ItemOfferHeading = Box.withConfig<{
-  $isApplied: boolean
-}>(p => ({
+export const ItemOfferHeading = Box.withConfig<{ $isApplied: boolean }>(p => ({
   _text: {
     fontSize: 10,
     textTransform: 'uppercase',
@@ -24,10 +20,7 @@ export const ItemOfferHeading = Box.withConfig<{
   },
 }))
 
-export const Y = Box.withConfig<{
-  $isApplied: boolean,
-  center: boolean
-}>(p => ({
+export const Y = Box.withConfig<{ center: boolean, $isApplied: boolean }>(p => ({
   _text: {
     color: p.$isApplied ? Styles.color.black : Styles.color.red,
   },
@@ -35,10 +28,7 @@ export const Y = Box.withConfig<{
   alignItems: p.center ? 'center' : 'flex-end',
 }));
 
-export const Z = Box.withConfig<{
-  center: boolean,
-  $isApplied: boolean
-}>(p => ({
+export const Z = Box.withConfig<{ center: boolean, $isApplied: boolean }>(p => ({
   alignItems: p.center ? 'center' : 'flex-end',
   alignSelf: p.center ? 'center' : 'flex-end',
 

--- a/examples/__testfixtures__/styled-components-to-ucl/complex6.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex6.output.ts
@@ -8,9 +8,7 @@ export interface IMethodContainer {
   $isClickable?: boolean;
 }
 
-export const MethodTypeWrapper = Box.withConfig<{
-  $isClickable: boolean
-}>(p => ({
+export const MethodTypeWrapper = Box.withConfig<IMethodContainer>(p => ({
   justifyContent: 'center',
   paddingTop: 0,
   paddingRight: '$2',

--- a/examples/__testfixtures__/styled-components-to-ucl/single.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/single.input.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Box = styled.div`
+export const Box = styled.div<{secondary: boolean}>`
   width: 40;
   height: 4rem;
   top: ${p => (p.secondary ? '5vh' : '10vh')};

--- a/examples/__testfixtures__/styled-components-to-ucl/single.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/single.output.ts
@@ -1,8 +1,6 @@
 import { Box as UCLBox } from '@rbilabs/universal-components';
 
-export const Box = UCLBox.withConfig<{
-  secondary: boolean
-}>(p => ({
+export const Box = UCLBox.withConfig<{secondary: boolean}>(p => ({
   width: '$10',
   height: '$16',
   top: p.secondary ? '5vh' : '10vh',

--- a/examples/__testfixtures__/styled-components-to-ucl/types.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/types.input.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+type Baz = true
+
+// Tests to prove we can carry over the types as expected
+export const DivWithType = styled.div<Baz>``
+export const DivWithoutType = styled.div``
+export const DivWithInlineType = styled.div<{key: 'property'}>``

--- a/examples/__testfixtures__/styled-components-to-ucl/types.input.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/types.input.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import Modal from 'modal'
 
 type Baz = true
 
@@ -6,3 +7,4 @@ type Baz = true
 export const DivWithType = styled.div<Baz>``
 export const DivWithoutType = styled.div``
 export const DivWithInlineType = styled.div<{key: 'property'}>``
+export const DivFnWithInlineType = styled(Modal)<{key: 'property'}>``

--- a/examples/__testfixtures__/styled-components-to-ucl/types.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/types.output.ts
@@ -1,4 +1,5 @@
 import { Box } from '@rbilabs/universal-components';
+import Modal from 'modal'
 
 type Baz = true
 
@@ -6,3 +7,4 @@ type Baz = true
 export const DivWithType = Box.withConfig<Baz>({})
 export const DivWithoutType = Box.withConfig({})
 export const DivWithInlineType = Box.withConfig<{key: 'property'}>({})
+export const DivFnWithInlineType = Modal.withConfig<{key: 'property'}>({})

--- a/examples/__testfixtures__/styled-components-to-ucl/types.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/types.output.ts
@@ -1,0 +1,8 @@
+import { Box } from '@rbilabs/universal-components';
+
+type Baz = true
+
+// Tests to prove we can carry over the types as expected
+export const DivWithType = Box.withConfig<Baz>({})
+export const DivWithoutType = Box.withConfig({})
+export const DivWithInlineType = Box.withConfig<{key: 'property'}>({})

--- a/examples/__testfixtures__/wl-components/account-orders/styled.base.output.ts
+++ b/examples/__testfixtures__/wl-components/account-orders/styled.base.output.ts
@@ -10,7 +10,9 @@ export const ScrollContainer = Box.withConfig({
   // height: 'calc(100% - 164px)',
 
   paddingTop: '124px',
-  overflowY: 'auto',
+
+  // TODO: RN - unsupported CSS
+  // overflowY: 'auto',
 });
 
 export const TrackOrderLink = Link.withConfig({
@@ -191,12 +193,12 @@ export const CateringPendingApproval = Text.withConfig({
   margin: 0,
 });
 
-export const NumItems = Text.withConfig({
+export const NumItems = Box.withConfig({
   marginLeft: '$1',
 });
 
 export const Items = Text.withConfig({
-  lineHeight: 24,
+  lineHeight: 'lg',
   maxHeight: 48,
   paddingRight: '$4',
   overflow: 'hidden',
@@ -255,6 +257,7 @@ export const RecentOrderTitle = Header.withConfig({
   // TODO: This should not be like this
   color: '__2substitution__ !important',
   textAlign: 'center',
+  variant: 'headerTwo',
 
   fontSize: {
     base: 36,

--- a/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
+++ b/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
@@ -1,4 +1,4 @@
-import { Box, Header } from '@rbilabs/universal-components';
+import { Box, FormControl, Header } from '@rbilabs/universal-components';
 
 import { ClickableContainer } from 'components/clickable-container';
 import { brandFont } from 'components/layout/brand-font';
@@ -11,9 +11,7 @@ import { RewardsStyleVariant, WithStyleVariant } from '../types';
 
 import { CategoryDropdownProps, OptionsContainerProps } from './types';
 
-export const CategoryTitle = Header.withConfig<{
-  variant: boolean
-}>(p => ({
+export const CategoryTitle = Header.withConfig<WithStyleVariant>(p => ({
   height: '$12',
   flexWrap: 'wrap',
   margin: 0,
@@ -24,6 +22,7 @@ export const CategoryTitle = Header.withConfig<{
     : '__legacyToken.text-default',
 
   fontWeight: p.variant ? Styles.fontWeight.normal : 'inherit',
+  variant: 'headerFive',
 
   fontSize: {
     lg: 19,
@@ -38,9 +37,7 @@ export const noBottomBorder = {
   borderBottomRightRadius: 0,
 };
 
-export const CategoryContainer = Box.withConfig<{
-  variant: boolean
-}>(p => ({
+export const CategoryContainer = Box.withConfig<WithStyleVariant>(p => ({
   paddingX: '$4',
   paddingY: 0,
   borderTopWidth: 1,
@@ -78,7 +75,7 @@ export const CategoryContainer = Box.withConfig<{
   // boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.1)',
 }));
 
-export const Fieldset = Box.withConfig({
+export const Fieldset = FormControl.withConfig({
   borderWidth: 0,
   borderColor: 'black',
   borderStyle: 'solid',
@@ -88,13 +85,13 @@ export const Fieldset = Box.withConfig({
   margin: 0,
   padding: 0,
   width: '100%',
-});
+})/* TODO: RN - This was a <input> tag. Verify its styled properly*/;
 
 export const HiddenLegend = Box.withConfig({
   ...screenReaderOnly,
-});
+})/* TODO: RN - This was a <legend> tag. Verify its styled properly*/;
 
-export const CategoryDropdownContainer = CategoryContainer.withConfig({
+export const CategoryDropdownContainer = CategoryContainer.withConfig<Pick<CategoryDropdownProps, 'optionsVisible' | 'overlay'>>({
   width: '100%',
   padding: 0,
   // ${({ optionsVisible, overlay }) => overlay && optionsVisible && noBottomBorder};
@@ -108,17 +105,14 @@ export const TitleContainer = Box.withConfig({
   width: '100%',
 });
 
-export const Title = ClickableContainer.withConfig<{
-  showBorder: boolean,
-  variant: boolean
-}>(p => ({
+export const Title = ClickableContainer.withConfig<{ isUsingTabNavigation: boolean; showBorder: boolean; bold: boolean } & WithStyleVariant>(p => ({
   alignItems: 'space-between',
   justifyContent: 'center',
   borderBottomWidth: 1,
   borderBottomColor: p.showBorder ? '1px' : '0px',
   borderBottomStyle: 'solid',
-  borderBottomStyle: 'solid',
 
+  // This should be commented out i think and kept
   borderBottomColor: p.variant
     ? 'blackOpacity.30'
     : '__legacyToken.border-color-default',
@@ -194,12 +188,11 @@ export const overlayStyle = p => ({
 
   borderWidth: 0,
   borderColor: 'black',
-  borderStyle: 'solid',
   borderBottomLeftRadius: 8,
   borderBottomRightRadius: 8,
 });
 
-export const OptionsContainer = Box.withConfig({
+export const OptionsContainer = Box.withConfig<OptionsContainerProps>({
   paddingX: '$4',
   paddingY: 0,
   zIndex: Styles.zIndex.normal,

--- a/examples/__tests__/styled-components-to-ucl.spec.ts
+++ b/examples/__tests__/styled-components-to-ucl.spec.ts
@@ -21,6 +21,7 @@ describe("styled-components to UCL", () => {
   defineTest(__dirname, '../codemods', null, 'styled-components-to-ucl/should-ignore', { parser: 'tsx' });
   defineTest(__dirname, '../codemods', null, 'styled-components-to-ucl/single', { parser: 'ts' });
   defineTest(__dirname, '../codemods', null, 'styled-components-to-ucl/spacing', { parser: 'ts' });
+  defineTest(__dirname, '../codemods', null, 'styled-components-to-ucl/types', { parser: 'ts' });
   defineTest(__dirname, '../codemods', null, 'styled-components-to-ucl/unsupported', { parser: 'ts' });
   // @ts-ignore
   defineTest(__dirname, '../codemods', null, 'styled-components-to-ucl/js-file', { parser: 'js' });


### PR DESCRIPTION
This makes sure we carry over the prop definitions from the `styled.div<Foo>` and injects them to the `Box.withConfig<Foo>()`