### PR TITLE
Undo flex flipping and inject flexDirection=row

### DIFF
--- a/codemods/utils/convert-css-object.ts
+++ b/codemods/utils/convert-css-object.ts
@@ -243,6 +243,10 @@ export const addProperties = ({
   let parent = _parent;
   let newPropertyName = _newPropertyName;
 
+  if (!parent && _needFlexRemapping) {
+    properties.push(j.property('init', j.identifier('flexDirection'), j.literal('row')));
+  }
+
   // If the initialValue is an object, iterate over the keys
   if (_.isObject(initialValue)) {
     // Check for supported object properties
@@ -264,7 +268,7 @@ export const addProperties = ({
         parent: parent,
         newPropertyName: k,
         originalPropertyNewName: null,
-        needsFlexRemapping: needsFlexRemapping(obj),
+        needsFlexRemapping: false,
         localImportNames,
       });
     });
@@ -291,7 +295,7 @@ export const addProperties = ({
     value: _value,
     isSupported,
     isRemovable,
-  } = postToRNTransform(identifier, value.value, _needFlexRemapping);
+  } = postToRNTransform(identifier, value.value);
 
   let isChangingIdentifier = identifier !== _identifier;
   value.value = _value;

--- a/codemods/utils/mappings.ts
+++ b/codemods/utils/mappings.ts
@@ -435,7 +435,7 @@ export const preToRNTransform = (identifier, value, obj) => {
 
 // One-offs Post toRN
 // -------
-export const postToRNTransform = (identifier, value, needsFlexRemapping) => {
+export const postToRNTransform = (identifier, value) => {
   let i = identifier;
   let v = value;
   let isSupported = _isSupported(identifier, value);
@@ -449,19 +449,6 @@ export const postToRNTransform = (identifier, value, needsFlexRemapping) => {
   // Objects are not supported
   if (_.isObject(value)) {
     isSupported = false;
-  }
-
-  if (needsFlexRemapping) {
-    // TODO push
-    // flexDirection: 'row',
-    switch (identifier) {
-      case 'justifyContent':
-        i = 'alignItems';
-        break;
-      case 'alignItems':
-        i = 'justifyContent';
-        break;
-    }
   }
 
   return {

--- a/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
@@ -8,6 +8,7 @@ export const Basic = Box.withConfig<{
   color: string;
   backgroundColor: string
 }>(p => ({
+  flexDirection: 'row',
   alignSelf: 'center',
 
   // TODO: RN - unsupported CSS
@@ -16,8 +17,8 @@ export const Basic = Box.withConfig<{
   // TODO: RN - unsupported CSS
   // boxShadow: 'inset 0px 1px 3px 0px rgba(0, 0, 0, 0.1)',
 
-  alignItems: 'space-between',
-  justifyContent: 'center',
+  justifyContent: 'space-between',
+  alignItems: 'center',
 
   _text: {
     textAlign: 'left',

--- a/examples/__testfixtures__/styled-components-to-ucl/complex.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex.output.ts
@@ -54,5 +54,6 @@ export const StyledContainer = Box.withConfig({
 });
 
 export const FlexRemapping = Box.withConfig({
-  alignItems: 'center',
+  flexDirection: 'row',
+  justifyContent: 'center',
 });

--- a/examples/__testfixtures__/styled-components-to-ucl/complex3.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex3.output.ts
@@ -15,8 +15,9 @@ export const BannerContainer = Box.withConfig({
 });
 
 export const TierLabel = Text.withConfig({
-  alignItems: 'center',
+  flexDirection: 'row',
   justifyContent: 'center',
+  alignItems: 'center',
   top: 0,
   left: 0,
   variant: 'headerTwo',

--- a/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
@@ -70,6 +70,7 @@ export const LoadingText = UCLText.withConfig({
 });
 
 export const LoadingGraphicWrapper = Box.withConfig({
+  flexDirection: 'row',
   height: '240px',
   width: '240px',
   borderTopLeftRadius: '50%',
@@ -80,8 +81,8 @@ export const LoadingGraphicWrapper = Box.withConfig({
   marginTop: '$4',
   backgroundColor: IMAGE_BACKGROUND_COLOR,
   overflow: 'hidden',
-  justifyContent: 'center',
   alignItems: 'center',
+  justifyContent: 'center',
 });
 
 export const GraphicTextWrapper = Box.withConfig({

--- a/examples/__testfixtures__/styled-components-to-ucl/complex5.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex5.output.ts
@@ -1,13 +1,13 @@
 import { Box } from '@rbilabs/universal-components';
 
 export const UnauthenticatedContainer = Box.withConfig<{ center: boolean }>(p => ({
+  flexDirection: 'row',
   paddingX: 0,
   paddingY: '$4',
   flexWrap: 'wrap',
-  flexDirection: 'row',
-  justifyContent: p.center ? 'center' : 'flex-end',
 
   alignItems: {
+    base: p.center ? 'center' : 'flex-end',
     lg: 'center',
   },
 }));

--- a/examples/__testfixtures__/styled-components-to-ucl/complex6.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex6.output.ts
@@ -9,7 +9,8 @@ export interface IMethodContainer {
 }
 
 export const MethodTypeWrapper = Box.withConfig<IMethodContainer>(p => ({
-  justifyContent: 'center',
+  flexDirection: 'row',
+  alignItems: 'center',
   paddingTop: 0,
   paddingRight: '$2',
   paddingBottom: 0,

--- a/examples/__testfixtures__/styled-components-to-ucl/css-template.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/css-template.output.ts
@@ -1,8 +1,9 @@
 import { Box, Text } from '@rbilabs/universal-components';
 
 export const TierLabel = Text.withConfig({
-  alignItems: 'center',
+  flexDirection: 'row',
   justifyContent: 'center',
+  alignItems: 'center',
   top: 0,
   left: 0,
   variant: 'headerTwo',

--- a/examples/__testfixtures__/wl-components/account-orders/styled.base.output.ts
+++ b/examples/__testfixtures__/wl-components/account-orders/styled.base.output.ts
@@ -206,7 +206,8 @@ export const Items = Text.withConfig({
 });
 
 export const ItemNameContainer = Box.withConfig({
-  justifyContent: 'center',
+  flexDirection: 'row',
+  alignItems: 'center',
 })/*
 TODO: RN - unsupported CSS
 Some attributes were not converted.
@@ -223,8 +224,9 @@ export const ItemNameContainer = styled.div`
 */;
 
 export const Wrap = Box.withConfig({
-  justifyContent: 'center',
+  flexDirection: 'row',
   alignItems: 'center',
+  justifyContent: 'center',
 
   height: {
     lg: 'auto',

--- a/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
+++ b/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
@@ -12,10 +12,11 @@ import { RewardsStyleVariant, WithStyleVariant } from '../types';
 import { CategoryDropdownProps, OptionsContainerProps } from './types';
 
 export const CategoryTitle = Header.withConfig<WithStyleVariant>(p => ({
+  flexDirection: 'row',
   height: '$12',
   flexWrap: 'wrap',
   margin: 0,
-  justifyContent: 'center',
+  alignItems: 'center',
 
   color: p.variant
     ? '__legacyToken.text-reversed'
@@ -106,8 +107,9 @@ export const TitleContainer = Box.withConfig({
 });
 
 export const Title = ClickableContainer.withConfig<{ isUsingTabNavigation: boolean; showBorder: boolean; bold: boolean } & WithStyleVariant>(p => ({
-  alignItems: 'space-between',
-  justifyContent: 'center',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
   borderBottomWidth: 1,
   borderBottomColor: p.showBorder ? '1px' : '0px',
   borderBottomStyle: 'solid',


### PR DESCRIPTION
This undo's the flex flipping logic we have in favor of injecting a `flexDirection: 'row'` when the previous iteration had a display: flex with no declared flex-direction.