### PR TITLE
Wrap local imports in makeUcl

### DIFF
--- a/codemods/index.ts
+++ b/codemods/index.ts
@@ -7,6 +7,7 @@ import { transformStyledCompoentsToUCL } from './styled-components-to-ucl';
 import { transformRenameOnclick } from './rename-onclick';
 import { transformComponentLibImports } from './components-lib-imports';
 import { ConversionError } from './utils/conversion-error';
+import { transformWrapinMakeUcl } from './wrap-make-ucl';
 
 export const parser = 'tsx';
 export default function transformer(fileInfo: FileInfo, api: API) {
@@ -20,6 +21,7 @@ export default function transformer(fileInfo: FileInfo, api: API) {
     transformRenameJSXPrimitives(root, j, fileInfo);
     transformStyledCompoentsToUCL(root, j, fileInfo);
     transformRenameOnclick(root, j, fileInfo);
+    transformWrapinMakeUcl(root, j, fileInfo);
   } catch (e) {
     if (e instanceof ConversionError) {
       console.error(e.reason);

--- a/codemods/wrap-make-ucl.ts
+++ b/codemods/wrap-make-ucl.ts
@@ -1,0 +1,62 @@
+import { Collection, FileInfo, JSCodeshift } from 'jscodeshift';
+import { registerImportSpecifiers } from './utils/register-ucl-import-specifiers';
+
+export function transformWrapinMakeUcl(root: Collection<any>, j: JSCodeshift, fileInfo: FileInfo) {
+  const importMap = collectImportsIntoMap(root, j);
+
+  // search for things like Modal.withConfig
+  // and if Modal is not from '@rbilabs/universal-components'
+  // then we convert it to `makeUclComponent(Modal).withConfig
+  root
+    .find(j.MemberExpression, {
+      property: {
+        name: 'withConfig',
+      },
+    })
+    .forEach(path => {
+      if (path.value.object.type !== 'Identifier') {
+        throw Error('unkonwn member expression type');
+      }
+
+      const ComponentName = path.value.object.name;
+
+      if (!importMap[ComponentName]) {
+        return;
+      }
+
+      const source = importMap[ComponentName];
+
+      if (source !== '@rbilabs/universal-components') {
+        registerImportSpecifiers(root, j, 'makeUclComponent');
+
+        path.value.object = j.callExpression.from({
+          callee: j.identifier('makeUclComponent'),
+          arguments: [path.value.object],
+        });
+      }
+    });
+}
+
+function collectImportsIntoMap(root: Collection<any>, j: JSCodeshift) {
+  // Map of ComponentName to import path
+  // e.g., { Modal: 'components/modal' }
+  const importMap = {};
+
+  // first collec
+  root.find(j.ImportDeclaration).forEach(p => {
+    const importName = p.value.source.value;
+
+    j(p)
+      .find(j.ImportSpecifier)
+      .forEach(p => {
+        importMap[p.value.local?.name ?? p.value.imported.name] = importName;
+      });
+    j(p)
+      .find(j.ImportDefaultSpecifier)
+      .forEach(p => {
+        importMap[p.value.local.name] = importName;
+      });
+  });
+
+  return importMap;
+}

--- a/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
@@ -1,4 +1,4 @@
-import { Box, Header as UCLHeader } from '@rbilabs/universal-components';
+import { Box, Header as UCLHeader, makeUclComponent } from '@rbilabs/universal-components';
 import Modal from './modal';
 
 /**
@@ -64,6 +64,6 @@ export const Conditional = Box.withConfig<{ reversed: boolean }>(p => ({
   backgroundColor: p.reversed ? Styles.color.white : '__legacyToken.text-default',
 }));
 
-export const ModalExtended = Modal.withConfig({
+export const ModalExtended = makeUclComponent(Modal).withConfig({
   backgroundColor: '__legacyToken.background-pattern',
 });

--- a/examples/__testfixtures__/styled-components-to-ucl/complex.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex.output.ts
@@ -1,10 +1,10 @@
-import { Box } from '@rbilabs/universal-components';
+import { Box, makeUclComponent } from '@rbilabs/universal-components';
 
 import CloseButton from 'components/close-button';
 import { FIXED_STICKY_FOOTER_HEIGHT } from 'components/sticky-footer/constants';
 import { primitive } from 'styles/constants/primitives';
 
-export const ModalCloseButton = CloseButton.withConfig({
+export const ModalCloseButton = makeUclComponent(CloseButton).withConfig({
   paddingTop: '$20',
 
   // TODO: RN - unsupported CSS

--- a/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
@@ -1,4 +1,4 @@
-import { Box, Button, Text as UCLText } from '@rbilabs/universal-components';
+import { Box, Button, makeUclComponent, Text as UCLText } from '@rbilabs/universal-components';
 
 import { ModalContent } from '../styled';
 import { ModalHeading } from 'components/modal';
@@ -26,12 +26,12 @@ export const AnotherOne = Box.withConfig<{ secondary: boolean }>(p => ({
   backgroundColor: theme.backgroundColor,
 }));
 
-export const Container = ModalContent.withConfig({
+export const Container = makeUclComponent(ModalContent).withConfig({
   height: '100%',
   alignItems: 'center',
 });
 
-export const StyledModalHeader = ModalHeading.withConfig({
+export const StyledModalHeader = makeUclComponent(ModalHeading).withConfig({
   alignSelf: 'center',
   lineHeight: '3xl',
   paddingBottom: 0,

--- a/examples/__testfixtures__/styled-components-to-ucl/types.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/types.output.ts
@@ -1,4 +1,4 @@
-import { Box } from '@rbilabs/universal-components';
+import { Box, makeUclComponent } from '@rbilabs/universal-components';
 import Modal from 'modal'
 
 type Baz = true
@@ -7,4 +7,4 @@ type Baz = true
 export const DivWithType = Box.withConfig<Baz>({})
 export const DivWithoutType = Box.withConfig({})
 export const DivWithInlineType = Box.withConfig<{key: 'property'}>({})
-export const DivFnWithInlineType = Modal.withConfig<{key: 'property'}>({})
+export const DivFnWithInlineType = makeUclComponent(Modal).withConfig<{key: 'property'}>({})

--- a/examples/__testfixtures__/wl-components/account-orders/styled.base.output.ts
+++ b/examples/__testfixtures__/wl-components/account-orders/styled.base.output.ts
@@ -1,4 +1,4 @@
-import { Box, Button, Header, Text } from '@rbilabs/universal-components';
+import { Box, Button, Header, makeUclComponent, Text } from '@rbilabs/universal-components';
 
 import { Container as EmptyStateContainer } from 'components/empty-state';
 import { brandFont } from 'components/layout/brand-font';
@@ -15,7 +15,7 @@ export const ScrollContainer = Box.withConfig({
   // overflowY: 'auto',
 });
 
-export const TrackOrderLink = Link.withConfig({
+export const TrackOrderLink = makeUclComponent(Link).withConfig({
   borderWidth: 1,
   borderColor: '__legacyToken.border-color-button-secondary',
   borderStyle: 'solid',
@@ -31,7 +31,6 @@ export const TrackOrderLink = Link.withConfig({
   paddingLeft: '$3',
   fontSize: '0.7em',
   color: '__legacyToken.text-button-secondary',
-  appearance: 'none',
   fontWeight: '500',
   underline: false,
   textTransform: 'uppercase',

--- a/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
+++ b/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
@@ -1,4 +1,4 @@
-import { Box, FormControl, Header } from '@rbilabs/universal-components';
+import { Box, FormControl, Header, makeUclComponent } from '@rbilabs/universal-components';
 
 import { ClickableContainer } from 'components/clickable-container';
 import { brandFont } from 'components/layout/brand-font';
@@ -106,7 +106,7 @@ export const TitleContainer = Box.withConfig({
   width: '100%',
 });
 
-export const Title = ClickableContainer.withConfig<{ isUsingTabNavigation: boolean; showBorder: boolean; bold: boolean } & WithStyleVariant>(p => ({
+export const Title = makeUclComponent(ClickableContainer).withConfig<{ isUsingTabNavigation: boolean; showBorder: boolean; bold: boolean } & WithStyleVariant>(p => ({
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',


### PR DESCRIPTION
This will take any `withConfig` calls, and if its reference is from a local import, it'll wrap it in `makeUclComponent`.


Question: Should we add a TODO to have engineers prune these?