### PR TITLE
Drop border*Style property

### DIFF
--- a/codemods/css-to-react-native.js
+++ b/codemods/css-to-react-native.js
@@ -159,7 +159,7 @@ var border = function border(prefix) {
       (_ref = {}),
       (_ref['border' + prefix + 'Width'] = borderWidth),
       (_ref['border' + prefix + 'Color'] = borderColor),
-      (_ref['border' + prefix + 'Style'] = borderStyle),
+      (_ref['borderStyle'] = borderStyle),
       _ref
     );
   };

--- a/codemods/utils/mappings.ts
+++ b/codemods/utils/mappings.ts
@@ -106,6 +106,10 @@ const removePropertyValuePairs = [
 
 // Props only
 const removeProperties = [
+  /^borderBottomStyle/,
+  /^borderTopStyle/,
+  /^borderLeftStyle/,
+  /^borderRightStyle/,
   /^animation/,
   /^appearance/,
   /^transition/,

--- a/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/basic.output.ts
@@ -28,7 +28,7 @@ export const Basic = Box.withConfig<{
   backgroundColor: p.backgroundColor,
   borderTopWidth: 1,
   borderTopColor: Styles.color.primary,
-  borderTopStyle: 'solid',
+  borderStyle: 'solid',
   padding: 0,
 }));
 

--- a/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/complex4.output.ts
@@ -37,7 +37,7 @@ export const StyledModalHeader = makeUclComponent(ModalHeading).withConfig({
   paddingBottom: 0,
   borderBottomWidth: 0,
   borderBottomColor: 'black',
-  borderBottomStyle: 'solid',
+  borderStyle: 'solid',
 
   paddingTop: {
     lg: 0,

--- a/examples/__testfixtures__/styled-components-to-ucl/css-template.output.ts
+++ b/examples/__testfixtures__/styled-components-to-ucl/css-template.output.ts
@@ -85,7 +85,7 @@ const LinkStyles = {
     lg: 'black',
   },
 
-  borderBottomStyle: {
+  borderStyle: {
     base: 'solid',
     lg: 'solid',
   },

--- a/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
+++ b/examples/__testfixtures__/wl-components/reward-categories/components/styled.output.tsx
@@ -82,7 +82,6 @@ export const Fieldset = FormControl.withConfig({
   borderStyle: 'solid',
   borderTopWidth: 1,
   borderTopColor: '__legacyToken.border-color-default',
-  borderTopStyle: 'solid',
   margin: 0,
   padding: 0,
   width: 'full',
@@ -112,7 +111,7 @@ export const Title = makeUclComponent(ClickableContainer).withConfig<{ isUsingTa
   alignItems: 'center',
   borderBottomWidth: 1,
   borderBottomColor: p.showBorder ? '1px' : '0px',
-  borderBottomStyle: 'solid',
+  borderStyle: 'solid',
 
   // This should be commented out i think and kept
   borderBottomColor: p.variant


### PR DESCRIPTION
Makes sure we don't install `border*Style` properties. They are not valid css in react native. Only `borderStyle` is allowed.

Primarily fixed in the css-to-react-native layer, but also a couple fixes for specific css bits `border-bottom-style: solid`